### PR TITLE
Disable deploy to GH-PAGES

### DIFF
--- a/paddle/scripts/travis/build_doc.sh
+++ b/paddle/scripts/travis/build_doc.sh
@@ -60,14 +60,10 @@ function deploy_docs() {
   set +e
   rm -rf ${DIR}/doc ${DIR}/doc_cn
   set -e
-  mv ../doc/cn/html ${DIR}/doc_cn
-  mv ../doc/en/html ${DIR}/doc
+  cp -r ../doc/cn/html ${DIR}/doc_cn
+  cp -r ../doc/en/html ${DIR}/doc
   git add .
 }
-
-deploy_docs "master" "."
-deploy_docs "develop" "./develop/"
-
 
 if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   if [ "$TRAVIS_BRANCH" == "develop" ]; then
@@ -81,29 +77,33 @@ else
   echo "Skipping document deployment to paddlepaddle.org on pull request"
 fi
 
+# Disable deploy to gh-pages for now, re-enable this when we merge into paddlepaddle/develop
+#deploy_docs "master" "."
+#deploy_docs "develop" "./develop/"
+
 
 # Check is there anything changed.
-set +e
-git diff --cached --exit-code >/dev/null
-if [ $? -eq 0 ]; then
-  echo "No changes to the output on this push; exiting."
-  exit 0
-fi
-set -e
+# set +e
+# git diff --cached --exit-code >/dev/null
+# if [ $? -eq 0 ]; then
+#   echo "No changes to the output on this push; exiting."
+#   exit 0
+# fi
+# set -e
 
-if [ -n $SSL_KEY ]; then  # Only push updated docs for github.com/PaddlePaddle/Paddle.
-  # Commit
-  git add .
-  git config user.name "Travis CI"
-  git config user.email "paddle-dev@baidu.com"
-  git commit -m "Deploy to GitHub Pages: ${SHA}"
-  # Set ssh private key
-  openssl aes-256-cbc -K $SSL_KEY -iv $SSL_IV -in ../../paddle/scripts/travis/deploy_key.enc -out deploy_key -d
-  chmod 600 deploy_key
-  eval `ssh-agent -s`
-  ssh-add deploy_key
-
-  # Push
-  git push $SSH_REPO $TARGET_BRANCH
-
-fi
+# if [ -n $SSL_KEY ]; then  # Only push updated docs for github.com/PaddlePaddle/Paddle.
+#   # Commit
+#   git add .
+#   git config user.name "Travis CI"
+#   git config user.email "paddle-dev@baidu.com"
+#   git commit -m "Deploy to GitHub Pages: ${SHA}"
+#   # Set ssh private key
+#   openssl aes-256-cbc -K $SSL_KEY -iv $SSL_IV -in ../../paddle/scripts/travis/deploy_key.enc -out deploy_key -d
+#   chmod 600 deploy_key
+#   eval `ssh-agent -s`
+#   ssh-add deploy_key
+# 
+#   # Push
+#   git push $SSH_REPO $TARGET_BRANCH
+# 
+# fi

--- a/paddle/scripts/travis/docs_requirements.txt
+++ b/paddle/scripts/travis/docs_requirements.txt
@@ -20,7 +20,7 @@ Pygments==2.2.0
 pytz==2017.2
 rarfile==3.0
 recommonmark==0.4.0
-requests==2.18.4
+requests==2.9.2
 scipy==0.19.1
 six==1.11.0
 snowballstemmer==1.2.1


### PR DESCRIPTION
Disable deploy to GH-PAGES, since we don't have the public key in bobateadev repo.  Will re-enable when we merge into paddlepaddle/Paddle